### PR TITLE
singleton + relative methods + event args + fix pinch to scale + mark events as attended

### DIFF
--- a/src/ofxGestures.cpp
+++ b/src/ofxGestures.cpp
@@ -6,31 +6,40 @@
 //
 
 #include "ofxGestures.h"
-#include "MathUtils.h"
+
+ofxGestures & ofxGestures::get(){
+	static ofxGestures * instance = new ofxGestures();
+	return *instance;
+}
 
 ofxGestures::ofxGestures():
 m_isPanning(false),
 m_isPinching(false)
 {
-    ofAddListener(ofEvents().touchDown, this, &ofxGestures::touchDown);
-	ofAddListener(ofEvents().touchMoved, this, &ofxGestures::touchMoved);
-    ofAddListener(ofEvents().touchUp, this, &ofxGestures::touchUp);
+    ofAddListener(ofEvents().touchDown, this, &ofxGestures::touchDown, OF_EVENT_ORDER_BEFORE_APP);
+	ofAddListener(ofEvents().touchMoved, this, &ofxGestures::touchMoved, OF_EVENT_ORDER_BEFORE_APP);
+    ofAddListener(ofEvents().touchUp, this, &ofxGestures::touchUp, OF_EVENT_ORDER_BEFORE_APP);
 }
 
 ofxGestures::~ofxGestures()
 {
-    ofRemoveListener(ofEvents().touchDown, this, &ofxGestures::touchDown);
-	ofRemoveListener(ofEvents().touchMoved, this, &ofxGestures::touchMoved);
-    ofRemoveListener(ofEvents().touchUp, this, &ofxGestures::touchUp);
+    ofRemoveListener(ofEvents().touchDown, this, &ofxGestures::touchDown, OF_EVENT_ORDER_BEFORE_APP);
+	ofRemoveListener(ofEvents().touchMoved, this, &ofxGestures::touchMoved, OF_EVENT_ORDER_BEFORE_APP);
+    ofRemoveListener(ofEvents().touchUp, this, &ofxGestures::touchUp, OF_EVENT_ORDER_BEFORE_APP);
 }
 
-void ofxGestures::touchDown(ofTouchEventArgs & touch) {
+bool ofxGestures::touchDown(ofTouchEventArgs & touch) {
     m_touches[touch.id] = touch;
+    bool attended = false;
     
     //check if should stop panning
     if (m_isPanning && m_touches.size() > 1)
     {
-        ofNotifyEvent(panGestureEndedEvent);
+        try{
+        	panGestureEndedEvent.notify(this,pan);
+        }catch(...){
+            attended = true;
+        }
         
         m_isPanning = false;
     }
@@ -42,8 +51,12 @@ void ofxGestures::touchDown(ofTouchEventArgs & touch) {
         
         m_panOrigin = m_touches[0];
         m_panCurrent = m_touches[0];
-        
-        ofNotifyEvent(panGestureEvent);
+
+        try{
+        	panGestureEvent.notify(this,pan);
+        }catch(...){
+            attended = true;
+        }
     }
     
     //check if should start pinching
@@ -55,45 +68,75 @@ void ofxGestures::touchDown(ofTouchEventArgs & touch) {
         m_pinchOrigin2 = m_touches[1];
         m_pinchCurrent1 = m_touches[0];
         m_pinchCurrent2 = m_touches[1];
-        
-        ofNotifyEvent(pinchGestureEvent);
+        m_pinchPrevious1 = m_touches[0];
+        m_pinchPrevious2 = m_touches[1];
+
+        try{
+        	pinchGestureEvent.notify(this,pinch);
+        }catch(...){
+            attended = true;
+        }
     }
+
+    return attended;
 };
 
-void ofxGestures::touchMoved(ofTouchEventArgs & touch) {
+bool ofxGestures::touchMoved(ofTouchEventArgs & touch) {
     m_touches[touch.id] = touch;
+    bool attended = false;
     
     if (m_isPanning && touch.id == 0)
     {
         m_panCurrent = touch;
-        
-        ofNotifyEvent(panGestureEvent);
+
+        try{
+        	panGestureEvent.notify(this,pan);
+        }catch(...){
+            attended = true;
+        }
     }
     
     if (m_isPinching && touch.id == 0)
     {
         m_pinchCurrent1 = touch;
-        
-        ofNotifyEvent(pinchGestureEvent);
+
+        try{
+        	pinchGestureEvent.notify(this,pinch);
+        }catch(...){
+            attended = true;
+        }
+
+        m_pinchPrevious1 = m_pinchCurrent1;
     }
     
     if (m_isPinching && touch.id == 1)
     {
         m_pinchCurrent2 = touch;
-        
-        ofNotifyEvent(pinchGestureEvent);
+
+        try{
+        	pinchGestureEvent.notify(this,pinch);
+        }catch(...){
+            attended = true;
+        }
+
+        m_pinchPrevious2 = m_pinchCurrent2;
     }
+    return attended;
 };
 
-void ofxGestures::touchUp(ofTouchEventArgs & touch) {
+bool ofxGestures::touchUp(ofTouchEventArgs & touch) {
     m_touches.erase(touch.id);
+    bool attended = false;
     
     if (m_isPanning)
     {
         if (!touchExists(0))   
         {
-            ofNotifyEvent(panGestureEndedEvent);
-            
+            try{
+            	panGestureEndedEvent.notify(this,pan);
+            }catch(...){
+                attended = true;
+            }
             m_isPanning = false;
         }
     }
@@ -102,11 +145,15 @@ void ofxGestures::touchUp(ofTouchEventArgs & touch) {
     {
         if (!touchExists(0) || !touchExists(1))
         {
-            ofNotifyEvent(pinchGestureEndedEvent);
-            
+            try{
+            	pinchGestureEndedEvent.notify(this,pinch);
+            }catch(...){
+                attended = true;
+            }
             m_isPinching = false;
         }
     }
+    return attended;
 };
 
 ofVec2f ofxGestures::getPanOrigin() const
@@ -137,11 +184,11 @@ double ofxGestures::getPinchAngle() const
     double currentLength = sqrt(pow(currentDelta.x, 2) + pow(currentDelta.y, 2));
     double originLength = sqrt(pow(originDelta.x, 2) + pow(originDelta.y, 2));
     
-    double currentAngle = rad2deg(asin(currentDelta.x / currentLength));
-    double originAngle = rad2deg(asin(originDelta.x / originLength));
+    double currentAngle = ofRadToDeg(asin(currentDelta.x / currentLength));
+    double originAngle = ofRadToDeg(asin(originDelta.x / originLength));
     
     if (m_pinchCurrent2.y > m_pinchCurrent1.y) currentAngle = 180.0 - currentAngle;
-    if ( m_pinchOrigin2.y >  m_pinchOrigin1.y)  originAngle = 180.0 - originAngle;
+    if ( m_pinchOrigin2.y >  m_pinchOrigin1.y) originAngle = 180.0 - originAngle;
     
     return currentAngle - originAngle;
 }
@@ -154,5 +201,80 @@ double ofxGestures::getPinchScale() const
     double currentLength = sqrt(pow(currentDelta.x, 2) + pow(currentDelta.y, 2));
     double originLength = sqrt(pow(originDelta.x, 2) + pow(originDelta.y, 2));
     
-    return originLength / currentLength;
+    return currentLength / originLength;
+}
+
+
+ofVec2f ofxGestures::getPinchPrevious() const{
+    return (m_pinchPrevious2 + m_pinchPrevious1) / 2.0;
+}
+
+ofVec2f ofxGestures::getPinchRelativeDelta() const{
+    return (m_pinchCurrent2 + m_pinchCurrent1 - m_pinchPrevious2 - m_pinchPrevious1) / 2.0;
+}
+
+double ofxGestures::getPinchRelativeAngle() const{
+    ofVec2f currentDelta = m_pinchCurrent2 - m_pinchCurrent1;
+    ofVec2f previousDelta = m_pinchPrevious2 - m_pinchPrevious1;
+
+    double currentLength = sqrt(pow(currentDelta.x, 2) + pow(currentDelta.y, 2));
+    double previousLength = sqrt(pow(previousDelta.x, 2) + pow(previousDelta.y, 2));
+
+    double currentAngle = ofRadToDeg(asin(currentDelta.x / currentLength));
+    double previousAngle = ofRadToDeg(asin(previousDelta.x / previousLength));
+
+    if (m_pinchCurrent2.y > m_pinchCurrent1.y) currentAngle = 180.0 - currentAngle;
+    if (m_pinchPrevious2.y >  m_pinchPrevious1.y) previousAngle = 180.0 - previousAngle;
+
+    return currentAngle - previousAngle;
+}
+
+double ofxGestures::getPinchRelativeScale() const{
+    ofVec2f currentDelta = m_pinchCurrent2 - m_pinchCurrent1;
+    ofVec2f previousDelta = m_pinchPrevious2 - m_pinchPrevious1;
+
+    double currentLength = sqrt(pow(currentDelta.x, 2) + pow(currentDelta.y, 2));
+    double previousLength = sqrt(pow(previousDelta.x, 2) + pow(previousDelta.y, 2));
+
+    return currentLength / previousLength;
+}
+
+ofVec2f ofxGestures::PinchEvent::getOrigin() const{
+	return ofxGestures::get().getPinchOrigin();
+}
+
+ofVec3f ofxGestures::PinchEvent::getPrevious() const{
+	return ofxGestures::get().getPinchPrevious();
+}
+
+ofVec2f ofxGestures::PinchEvent::getDelta() const{
+	return ofxGestures::get().getPinchDelta();
+}
+
+ofVec2f ofxGestures::PinchEvent::getRelativeDelta() const{
+	return ofxGestures::get().getPinchRelativeDelta();
+}
+
+double ofxGestures::PinchEvent::getAngle() const{
+	return ofxGestures::get().getPinchAngle();
+}
+
+double ofxGestures::PinchEvent::getScale() const{
+	return ofxGestures::get().getPinchScale();
+}
+
+double ofxGestures::PinchEvent::getRelativeAngle() const{
+	return ofxGestures::get().getPinchRelativeAngle();
+}
+
+double ofxGestures::PinchEvent::getRelativeScale() const{
+	return ofxGestures::get().getPinchRelativeScale();
+}
+
+ofVec2f ofxGestures::PanEvent::getOrigin() const{
+	return ofxGestures::get().getPanOrigin();
+}
+
+ofVec2f ofxGestures::PanEvent::getDelta() const{
+	return ofxGestures::get().getPanDelta();
 }

--- a/src/ofxGestures.h
+++ b/src/ofxGestures.h
@@ -9,54 +9,76 @@
 
 #include "ofMain.h"
 
+
 class ofxGestures
 {
-    
-private:
-    
-    std::map<int, ofTouchEventArgs> m_touches;
-    
-    bool m_isPanning;
-    ofTouchEventArgs m_panOrigin;
-    ofTouchEventArgs m_panCurrent;
-    
-    bool m_isPinching;
-    ofTouchEventArgs m_pinchOrigin1;
-    ofTouchEventArgs m_pinchOrigin2;
-    ofTouchEventArgs m_pinchCurrent1;
-    ofTouchEventArgs m_pinchCurrent2;
-    
 public:
-    
-    ofxGestures();
-    ~ofxGestures();
+    class PanEvent{
+    public:
+        ofVec2f getOrigin() const;
+        ofVec2f getDelta() const;
+    };
 
-private:
-    
-    void touchDown(ofTouchEventArgs & touch);
-    void touchMoved(ofTouchEventArgs & touch);
-    void touchUp(ofTouchEventArgs & touch);
-    
-    bool touchExists(int touchNum){return (m_touches.find(touchNum) != m_touches.end());}
+    ofEvent<PanEvent> panGestureEvent;
+    ofEvent<PanEvent> panGestureEndedEvent;
 
-public:
+    class PinchEvent{
+    public:
+        ofVec2f getOrigin() const;
+        ofVec3f getPrevious() const;
+        ofVec2f getDelta() const;
+        ofVec2f getRelativeDelta() const;
+        double getAngle() const;
+        double getScale() const;
+        double getRelativeAngle() const;
+        double getRelativeScale() const;
+    };
     
-    ofEvent<void> panGestureEvent;
-    ofEvent<void> panGestureEndedEvent;
+    ofEvent<PinchEvent> pinchGestureEvent;
+    ofEvent<PinchEvent> pinchGestureEndedEvent;
     
-    ofEvent<void> pinchGestureEvent;
-    ofEvent<void> pinchGestureEndedEvent;
-    
-public:
-    
+    static ofxGestures & get();
     bool isPanning() const {return m_isPanning;}
     ofVec2f getPanOrigin() const;
     ofVec2f getPanDelta() const;
     
     bool isPinching() const {return m_isPinching;}
     ofVec2f getPinchOrigin() const;
+    ofVec2f getPinchPrevious() const;
     ofVec2f getPinchDelta() const;
+    ofVec2f getPinchRelativeDelta() const;
     double getPinchAngle() const;
+    double getPinchRelativeAngle() const;
     double getPinchScale() const;
+    double getPinchRelativeScale() const;
+
+private:
+    bool touchDown(ofTouchEventArgs & touch);
+    bool touchMoved(ofTouchEventArgs & touch);
+    bool touchUp(ofTouchEventArgs & touch);
+
+    bool touchExists(int touchNum){return (m_touches.find(touchNum) != m_touches.end());}
+
+    std::map<int, ofTouchEventArgs> m_touches;
+
+    bool m_isPanning;
+    ofTouchEventArgs m_panOrigin;
+    ofTouchEventArgs m_panCurrent;
+
+    bool m_isPinching;
+    ofTouchEventArgs m_pinchOrigin1;
+    ofTouchEventArgs m_pinchOrigin2;
+    ofTouchEventArgs m_pinchPrevious1;
+    ofTouchEventArgs m_pinchPrevious2;
+    ofTouchEventArgs m_pinchCurrent1;
+    ofTouchEventArgs m_pinchCurrent2;
+
+    PinchEvent pinch;
+    PanEvent pan;
+
+    ofxGestures();
+
+public:
+    ~ofxGestures();
 };
 


### PR DESCRIPTION
have been taking a look at this. it works great and using it in combination with ofNode, makes it super easy to get pinch gestures working, i'll try to add an example. i've added some things and fixed some issues:

singleton: in case you want to use the addon from different classes
avoids to pass a reference around, and it's more similar to how other
OF event classes work

relative methods: when doing a pinch gesture it's easier to transform
based on the relative position from the last event, that way you don't
need the transformations at the beginning of the pinch gesture, only the
last ones or do relative transformations.

event args: added event args (that internally call the corresponding
ofxGesture methods) to make the syntax less verbose and more uniform
with how other OF events work

fix pinch to scale: was reversed, scaling up when closing the fingers
instead of the opposite

mark events as attended: now the events propagate the return value of
the listeners which make it possible to stop the touch events from being 
propagated further if a listener attended a pinch or pan event already
